### PR TITLE
Spawned process wasn't starting properly

### DIFF
--- a/scripts/startup/time.js
+++ b/scripts/startup/time.js
@@ -15,7 +15,7 @@ const cmd = args[0].split(" ");
 
 const startTime = new Date().getTime();
 
-const proc = spawn(cmd[0], cmd.slice(1));
+const proc = spawn(cmd[0], cmd.slice(1), { stdio: 'ignore' });
 
 const intervalHandle = setInterval(() => {
   request(targetUrl, (error, response, body) => {


### PR DESCRIPTION
Found I needed to set the `stdio` for the child process to ignore it for the script to complete successfully.

Without it, the default of `pipe` seemed to mean it started (I could see the spawned process) but never got to the point of taking requests before it died.

Maybe there's something else going on, but this worked for me